### PR TITLE
Убрана логика логирования

### DIFF
--- a/pyproto/baseCommands.py
+++ b/pyproto/baseCommands.py
@@ -4,8 +4,8 @@
 import sys
 
 from .message import Message
-from .logger import write_info
-
+from .logger import logger
+# import logging
 
 Unknown = "UNKNOWN"
 Error = "ERROR"
@@ -64,7 +64,7 @@ class BaseCommand:
         """
         Обработчик ситуации, при которой в ответ на команду приходит сообщение о том, что данная команда неизвестна
         """
-        write_info(f'[{msg.my_connection.getpeername()}] Unknown command for remote client! {msg.get_id()}')
+        logger.info(f'[{msg.my_connection.getpeername()}] Unknown command for remote client! {msg.get_id()}')
         # raise Exception('Команда неизвестна для удалённого клиента!')
 
     @staticmethod

--- a/pyproto/connection.py
+++ b/pyproto/connection.py
@@ -218,8 +218,6 @@ class Connection:
         Является обёрткой над методом send_message, не подразумевает получение ответа
         """
         msg = command.initial(self, *args, **kwargs)
-        # Шлем сообщение только если его вернул command.initial
-        # if msg is not None:
         self.send_message(msg, need_answer=False)
 
     def exec_command_sync(self, command, *args, **kwargs):
@@ -228,8 +226,6 @@ class Connection:
         отправка сущности "команда", с последующей обработкой ответа в синхронном режиме
         """
         msg = command.initial(self, *args, **kwargs)
-        # Шлем сообщение только если его вернул command.initial
-        # if not msg is None:
         self.send_message(msg, need_answer=True)
 
         time_of_start = time.time()

--- a/pyproto/logger.py
+++ b/pyproto/logger.py
@@ -1,34 +1,6 @@
-"""Модуль содержит локигу логирования"""
+"""Логер модуля pyproto"""
 
 import logging
-from .config import MAX_LOG_LENGHT
 
 
-LOG_FILE_NAME = 'app.log'
-
-
-def set_logging_config(folder='', file_name=LOG_FILE_NAME):
-    logging.basicConfig(
-        filename=folder + file_name,
-        filemode='a',
-        format='%(asctime)s - %(name)s - %(levelname)s : %(message)s',
-        level=logging.INFO)
-
-
-def msg_handler(decor_func):
-    def wrapper(msg):
-        msg = msg[:MAX_LOG_LENGHT]
-        # Дублирование выводов лога в stdout
-        print(msg)
-        decor_func(msg)
-    return wrapper
-
-
-@msg_handler
-def write_info(msg):
-    logging.info(msg)
-
-
-@msg_handler
-def write_error(msg):
-    logging.error(msg)
+logger = logging.getLogger("pyproto")

--- a/pyproto/message.py
+++ b/pyproto/message.py
@@ -3,7 +3,7 @@ from copy import copy
 from uuid import uuid4
 
 from .badSituations import NotConnectionException, UnknownCommandRecieved
-from .logger import write_error
+from .logger import logger
 from .tools import try_uuid
 from .flags import MsgFlag, Type, ExecStatus
 
@@ -134,7 +134,7 @@ class Message(dict):
 
     def tag(self, num=0):
         if num not in range(0, 254):
-            write_error("Index value not in range [0..254]")
+            logger.error("Index value not in range [0..254]")
             return 0
 
         if 'tags' not in self or len(self.get('tags')) < num + 1:

--- a/pyproto/tcpServer.py
+++ b/pyproto/tcpServer.py
@@ -3,7 +3,7 @@ from threading import Thread
 
 from .worker import TcpWorker
 from .connection import Connection
-from .logger import write_info
+from .logger import logger
 
 
 class TcpServer(TcpWorker):
@@ -18,7 +18,7 @@ class TcpServer(TcpWorker):
         while True:
             sock, adr = self.serv_socket.accept()
             connection = Connection(self, sock)
-            write_info(f'{connection.getpeername()} - was connected')
+            logger.info(f'{connection.getpeername()} - was connected')
             self.run_connection(connection)
 
             if new_client_handler:

--- a/pyproto/tcpSocket.py
+++ b/pyproto/tcpSocket.py
@@ -1,6 +1,6 @@
 from .connection import Connection
 from .worker import TcpWorker
-from .logger import write_info
+from .logger import logger
 
 
 class TcpSocket(TcpWorker):
@@ -16,10 +16,10 @@ class TcpSocket(TcpWorker):
                 return None
             self.run_connection(connection)
         except TimeoutError as te:
-            write_info(str(te))
+            logger.info(str(te))
             return None
         except TypeError as type_e:
-            write_info(str(type_e))
+            logger.info(str(type_e))
             return None
 
         if disconect_connection_handler:

--- a/pyproto/worker.py
+++ b/pyproto/worker.py
@@ -3,7 +3,7 @@ from threading import Thread
 from .badSituations import UnknownCommandRecieved
 from .commandList import CommandList
 from .connection import Connection
-from .logger import write_info, set_logging_config
+from .logger import logger
 from . import baseCommands
 from . import baseCommandsImpl
 from .baseCommandsImpl import CloseConnectionCommand, UnknownCommand
@@ -16,8 +16,6 @@ class TcpWorker:
     base_commands_list: CommandList
 
     def __init__(self, ip, port, client_commands, client_command_impl):
-        set_logging_config()
-
         self.ip = ip
         self.port = port
 
@@ -45,8 +43,8 @@ class TcpWorker:
 
     def get_command_name(self, command_uuid):
         """По UUID команды получаем Имя команды из списка базовых или из списка пользовательских"""
-        return self.base_commands_list.get_command_name(command_uuid) or \
-               self.user_commands_list.get_command_name(command_uuid)
+        return (self.base_commands_list.get_command_name(command_uuid) or
+                self.user_commands_list.get_command_name(command_uuid))
 
     def command_handler(self, msg):
         if msg.get_command() in self.base_commands_list:
@@ -72,14 +70,14 @@ class TcpWorker:
         while True:
             json_data = connection.mrecv()
             if json_data:
-                write_info(f'[{connection.getpeername()}] JSON received: {json_data}')
+                # logger.info(f'[{connection.getpeername()}] JSON received: {json_data}')
                 try:
                     msg = connection.message_from_json(json_data)  # Type: Message
                 except UnknownCommandRecieved:
-                    write_info(f'[{connection.getpeername()}] Unknown msg received')
+                    logger.info(f'[{connection.getpeername()}] Unknown msg received')
                     connection.exec_command(UnknownCommand, json_data)
                 else:
-                    write_info(f'[{connection.getpeername()}] Msg  received: {msg}')
+                    logger.info(f'[{connection.getpeername()}] Msg  received: {msg}')
                     # Это команда с той стороны, её нужно прям тут и обработать!
                     if msg.get_id() not in connection.request_pool:
                         self.command_handler(msg)
@@ -108,4 +106,4 @@ class TcpWorker:
             perr_name = conn.getpeername()
             conn.exec_command_sync(CloseConnectionCommand, code, description)
             conn.close()
-            write_info(f'[{perr_name}] Disconect from host')
+            logger.info(f'[{perr_name}] Disconect from host')


### PR DESCRIPTION
Создан экземпляр логера с именем пакета, настройки форматирования которого будут производиться пользователем библиотеки.

Не стоит форматировать логгер в библиотеке, так как в конечном счете это будет делать пользователь библиотеки следующим образом:

# Установка значения уровня логирования для pyproto
logging.getLogger("pyproto").setLevel(logging.ERROR)